### PR TITLE
Fix evocation recipe

### DIFF
--- a/nssm_weapons.lua
+++ b/nssm_weapons.lua
@@ -1234,7 +1234,7 @@ nssm_register_throwegg(evomob, evodescr.." Bomb", {
 minetest.register_craft({
 	output = 'nssm:'..evomob.."_bomb",
 	type = "shapeless",
-	recipe = {'nssm:empty_evocation_bomb', 'nssm:'..evomob.."_egg"},
+	recipe = {'nssm:empty_evocation_bomb', 'nssm:'..evomob},
 
 })
 


### PR DESCRIPTION
No more `_egg` needed for evocation bombs recipes