### PR TITLE
Fix call to set animation with newest mobs_redo

### DIFF
--- a/mobs/lava_titan.lua
+++ b/mobs/lava_titan.lua
@@ -88,7 +88,7 @@ mobs:register_mob("nssm:lava_titan", {
 	--[[
 	custom_attack = function (self)
 		digging_attack
-		mobs:set_animation(self, "punch")
+		mobs.set_animation(self, "punch")
 		local p2 = p
 		local s2 = s
 

--- a/mobs/lava_titan.lua
+++ b/mobs/lava_titan.lua
@@ -88,7 +88,7 @@ mobs:register_mob("nssm:lava_titan", {
 	--[[
 	custom_attack = function (self)
 		digging_attack
-		set_animation(self, "punch")
+		mobs:set_animation(self, "punch")
 		local p2 = p
 		local s2 = s
 

--- a/mobs/mese_dragon.lua
+++ b/mobs/mese_dragon.lua
@@ -99,7 +99,7 @@ mobs:register_mob("nssm:mese_dragon", {
 			end
 			if self.attack_rip>=8 then
 				self.attack_rip =0
-				set_animation("punch1")
+				mobs:set_animation("punch1")
 				for dx = -17,17 do
 					for dz= -17,17 do
 						local k = {x = s.x+dx, y=s.y+20, z=s.z+dz}

--- a/mobs/mese_dragon.lua
+++ b/mobs/mese_dragon.lua
@@ -99,7 +99,7 @@ mobs:register_mob("nssm:mese_dragon", {
 			end
 			if self.attack_rip>=8 then
 				self.attack_rip =0
-				mobs:set_animation("punch1")
+				mobs.set_animation("punch1")
 				for dx = -17,17 do
 					for dz= -17,17 do
 						local k = {x = s.x+dx, y=s.y+20, z=s.z+dz}

--- a/mobs/mordain.lua
+++ b/mobs/mordain.lua
@@ -60,7 +60,7 @@ mobs:register_mob("nssm:mordain", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 
-			mobs:set_animation(self, "punch")
+			mobs.set_animation(self, "punch")
 
 			if minetest.line_of_sight({x = p.x, y = p.y +1.5, z = p.z}, {x = s.x, y = s.y +1.5, z = s.z}) == true then
 				-- play attack sound

--- a/mobs/mordain.lua
+++ b/mobs/mordain.lua
@@ -60,7 +60,7 @@ mobs:register_mob("nssm:mordain", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 
-			set_animation(self, "punch")
+			mobs:set_animation(self, "punch")
 
 			if minetest.line_of_sight({x = p.x, y = p.y +1.5, z = p.z}, {x = s.x, y = s.y +1.5, z = s.z}) == true then
 				-- play attack sound

--- a/mobs/morde.lua
+++ b/mobs/morde.lua
@@ -62,7 +62,7 @@ mobs:register_mob("nssm:morde", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 
-			mobs:set_animation(self, "punch")
+			mobs.set_animation(self, "punch")
 
 			self.health = self.health + (self.damage*2)
 			local m = 3

--- a/mobs/morde.lua
+++ b/mobs/morde.lua
@@ -62,7 +62,7 @@ mobs:register_mob("nssm:morde", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 
-			set_animation(self, "punch")
+			mobs:set_animation(self, "punch")
 
 			self.health = self.health + (self.damage*2)
 			local m = 3

--- a/mobs/morgut.lua
+++ b/mobs/morgut.lua
@@ -69,7 +69,7 @@ mobs:register_mob("nssm:morgut", {
 
 		if self.flag == 1 then
 			self.state = ""
-			mobs:set_animation(self, "run")
+			mobs.set_animation(self, "run")
 			self.object:setyaw(self.dir)
 			set_velocity(self, 4)
 
@@ -89,7 +89,7 @@ mobs:register_mob("nssm:morgut", {
 			if self.attack then
 				local s = self.object:getpos()
 				local p = self.attack:getpos()
-				mobs:set_animation(self, "punch")
+				mobs.set_animation(self, "punch")
 				local m = 2
 
 				minetest.add_particlespawner(
@@ -149,7 +149,7 @@ mobs:register_mob("nssm:morgut", {
 									end
 								end
 							end
-							mobs:set_animation(self, "run")
+							mobs.set_animation(self, "run")
 							self.flag = 1
 							self.morgut_timer = os.time()
 							self.curr_attack = self.attack

--- a/mobs/morgut.lua
+++ b/mobs/morgut.lua
@@ -69,7 +69,7 @@ mobs:register_mob("nssm:morgut", {
 
 		if self.flag == 1 then
 			self.state = ""
-			set_animation(self, "run")
+			mobs:set_animation(self, "run")
 			self.object:setyaw(self.dir)
 			set_velocity(self, 4)
 
@@ -89,7 +89,7 @@ mobs:register_mob("nssm:morgut", {
 			if self.attack then
 				local s = self.object:getpos()
 				local p = self.attack:getpos()
-				set_animation(self, "punch")
+				mobs:set_animation(self, "punch")
 				local m = 2
 
 				minetest.add_particlespawner(
@@ -149,7 +149,7 @@ mobs:register_mob("nssm:morgut", {
 									end
 								end
 							end
-							set_animation(self, "run")
+							mobs:set_animation(self, "run")
 							self.flag = 1
 							self.morgut_timer = os.time()
 							self.curr_attack = self.attack

--- a/mobs/morlu.lua
+++ b/mobs/morlu.lua
@@ -71,7 +71,7 @@ mobs:register_mob("nssm:morlu", {
 
 		if self.flag == 1 then
 			self.state = ""
-			mobs:set_animation(self, "run")
+			mobs.set_animation(self, "run")
 			self.object:setyaw(self.dir)
 			set_velocity(self, 4)
 
@@ -91,7 +91,7 @@ mobs:register_mob("nssm:morlu", {
 
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
-			mobs:set_animation(self, "punch")
+			mobs.set_animation(self, "punch")
 			local m = 1
 
 			if self.attack:is_player() then
@@ -184,7 +184,7 @@ mobs:register_mob("nssm:morlu", {
 										self.inventory[self.invnum].name = armor_elements[steal_pos].name
 									end
 
-									mobs:set_animation(self, "run")
+									mobs.set_animation(self, "run")
 									self.flag = 1
 									self.morlu_timer = os.time()
 									self.curr_attack = self.attack
@@ -203,7 +203,7 @@ mobs:register_mob("nssm:morlu", {
 					local s = self.object:getpos()
 					local p = self.attack:getpos()
 
-					mobs:set_animation(self, "punch")
+					mobs.set_animation(self, "punch")
 
 					if minetest.line_of_sight({x = p.x, y = p.y +1.5, z = p.z}, {x = s.x, y = s.y +1.5, z = s.z}) == true then
 						-- play attack sound

--- a/mobs/morlu.lua
+++ b/mobs/morlu.lua
@@ -71,7 +71,7 @@ mobs:register_mob("nssm:morlu", {
 
 		if self.flag == 1 then
 			self.state = ""
-			set_animation(self, "run")
+			mobs:set_animation(self, "run")
 			self.object:setyaw(self.dir)
 			set_velocity(self, 4)
 
@@ -91,7 +91,7 @@ mobs:register_mob("nssm:morlu", {
 
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
-			set_animation(self, "punch")
+			mobs:set_animation(self, "punch")
 			local m = 1
 
 			if self.attack:is_player() then
@@ -184,7 +184,7 @@ mobs:register_mob("nssm:morlu", {
 										self.inventory[self.invnum].name = armor_elements[steal_pos].name
 									end
 
-									set_animation(self, "run")
+									mobs:set_animation(self, "run")
 									self.flag = 1
 									self.morlu_timer = os.time()
 									self.curr_attack = self.attack
@@ -203,7 +203,7 @@ mobs:register_mob("nssm:morlu", {
 					local s = self.object:getpos()
 					local p = self.attack:getpos()
 
-					set_animation(self, "punch")
+					mobs:set_animation(self, "punch")
 
 					if minetest.line_of_sight({x = p.x, y = p.y +1.5, z = p.z}, {x = s.x, y = s.y +1.5, z = s.z}) == true then
 						-- play attack sound

--- a/mobs/morvalar.lua
+++ b/mobs/morvalar.lua
@@ -79,7 +79,7 @@ mobs:register_mob("nssm:morvalar", {
 
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
-			set_animation(self, "punch")
+			mobs:set_animation(self, "punch")
 			local m = 1
 
 			if self.attack:is_player() then
@@ -157,7 +157,7 @@ mobs:register_mob("nssm:morvalar", {
 					local s = self.object:getpos()
 					local p = self.attack:getpos()
 
-					set_animation(self, "punch")
+					mobs:set_animation(self, "punch")
 
 					if minetest.line_of_sight({x = p.x, y = p.y +1.5, z = p.z}, {x = s.x, y = s.y +1.5, z = s.z}) == true then
 						-- play attack sound
@@ -240,7 +240,7 @@ mobs:register_mob("nssm:morvalar6", {
 
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
-			set_animation(self, "punch")
+			mobs:set_animation(self, "punch")
 			local m = 2
 
 
@@ -362,7 +362,7 @@ mobs:register_mob("nssm:morvalar5", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 			minetest.after(2, function(self)
-				set_animation(self, "punch")
+				mobs:set_animation(self, "punch")
 				tnt_boom_nssm(p, {damage_radius=6,radius=5,ignore_protection=false})
 				self.morvalar5_timer = os.time()
 			end,self)
@@ -431,7 +431,7 @@ mobs:register_mob("nssm:morvalar4", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 
-			set_animation(self, "punch")
+			mobs:set_animation(self, "punch")
 
 			if minetest.line_of_sight({x = p.x, y = p.y +1.5, z = p.z}, {x = s.x, y = s.y +1.5, z = s.z}) == true then
 				-- play attack sound
@@ -626,7 +626,7 @@ mobs:register_mob("nssm:morvalar2", {
 			end
 			minetest.chat_send_all("Ne ho contati: "..counter)
 			if counter < 2 then
-				set_animation(self, "punch")
+				mobs:set_animation(self, "punch")
 
 				local v = vector.subtract(p,s)
 				--local v = {x = s.x-p.x, y = s.y-p.y , z= s.z-p.z}
@@ -715,7 +715,7 @@ mobs:register_mob("nssm:morvalar1", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 
-			set_animation(self, "punch")
+			mobs:set_animation(self, "punch")
 
 			local m = 3
 
@@ -805,7 +805,7 @@ mobs:register_mob("nssm:morvalar0", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 
-			set_animation(self, "punch")
+			mobs:set_animation(self, "punch")
 
 			local m = 5 	--velocity of the kamehameha
 			local obj = minetest.add_entity(s, "nssm:kamehameha_bad")

--- a/mobs/morvalar.lua
+++ b/mobs/morvalar.lua
@@ -79,7 +79,7 @@ mobs:register_mob("nssm:morvalar", {
 
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
-			mobs:set_animation(self, "punch")
+			mobs.set_animation(self, "punch")
 			local m = 1
 
 			if self.attack:is_player() then
@@ -157,7 +157,7 @@ mobs:register_mob("nssm:morvalar", {
 					local s = self.object:getpos()
 					local p = self.attack:getpos()
 
-					mobs:set_animation(self, "punch")
+					mobs.set_animation(self, "punch")
 
 					if minetest.line_of_sight({x = p.x, y = p.y +1.5, z = p.z}, {x = s.x, y = s.y +1.5, z = s.z}) == true then
 						-- play attack sound
@@ -240,7 +240,7 @@ mobs:register_mob("nssm:morvalar6", {
 
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
-			mobs:set_animation(self, "punch")
+			mobs.set_animation(self, "punch")
 			local m = 2
 
 
@@ -362,7 +362,7 @@ mobs:register_mob("nssm:morvalar5", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 			minetest.after(2, function(self)
-				mobs:set_animation(self, "punch")
+				mobs.set_animation(self, "punch")
 				tnt_boom_nssm(p, {damage_radius=6,radius=5,ignore_protection=false})
 				self.morvalar5_timer = os.time()
 			end,self)
@@ -431,7 +431,7 @@ mobs:register_mob("nssm:morvalar4", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 
-			mobs:set_animation(self, "punch")
+			mobs.set_animation(self, "punch")
 
 			if minetest.line_of_sight({x = p.x, y = p.y +1.5, z = p.z}, {x = s.x, y = s.y +1.5, z = s.z}) == true then
 				-- play attack sound
@@ -626,7 +626,7 @@ mobs:register_mob("nssm:morvalar2", {
 			end
 			minetest.chat_send_all("Ne ho contati: "..counter)
 			if counter < 2 then
-				mobs:set_animation(self, "punch")
+				mobs.set_animation(self, "punch")
 
 				local v = vector.subtract(p,s)
 				--local v = {x = s.x-p.x, y = s.y-p.y , z= s.z-p.z}
@@ -715,7 +715,7 @@ mobs:register_mob("nssm:morvalar1", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 
-			mobs:set_animation(self, "punch")
+			mobs.set_animation(self, "punch")
 
 			local m = 3
 
@@ -805,7 +805,7 @@ mobs:register_mob("nssm:morvalar0", {
 			local s = self.object:getpos()
 			local p = self.attack:getpos()
 
-			mobs:set_animation(self, "punch")
+			mobs.set_animation(self, "punch")
 
 			local m = 5 	--velocity of the kamehameha
 			local obj = minetest.add_entity(s, "nssm:kamehameha_bad")

--- a/mobs/morvy.lua
+++ b/mobs/morvy.lua
@@ -55,10 +55,10 @@ mobs:register_mob("nssm:morvy", {
 	},
 
 	custom_attack = function(self)
-		mobs:set_animation(self, "stand")
+		mobs.set_animation(self, "stand")
 		self.morvy_counter = (self.morvy_counter or 0) + 1
 		if self.morvy_counter == 4 then
-			mobs:set_animation(self, "punch")
+			mobs.set_animation(self, "punch")
 			self.morvy_counter = 0
 			local counter = 0
 

--- a/mobs/morvy.lua
+++ b/mobs/morvy.lua
@@ -55,10 +55,10 @@ mobs:register_mob("nssm:morvy", {
 	},
 
 	custom_attack = function(self)
-		set_animation(self, "stand")
+		mobs:set_animation(self, "stand")
 		self.morvy_counter = (self.morvy_counter or 0) + 1
 		if self.morvy_counter == 4 then
-			set_animation(self, "punch")
+			mobs:set_animation(self, "punch")
 			self.morvy_counter = 0
 			local counter = 0
 

--- a/mobs/pumpking.lua
+++ b/mobs/pumpking.lua
@@ -62,7 +62,7 @@ mobs:register_mob("nssm:pumpking", {
 	custom_attack = function(self)
 		self.pumpking_timer = (self.pumpking_timer or os.time())
 		if (os.time() - self.pumpking_timer) >3 then
-			mobs:set_animation(self, "punch")
+			mobs.set_animation(self, "punch")
 			self.pumpking_timer = os.time()
 			local s = self.object:getpos()
 			local p = self.attack:getpos()

--- a/mobs/pumpking.lua
+++ b/mobs/pumpking.lua
@@ -62,7 +62,7 @@ mobs:register_mob("nssm:pumpking", {
 	custom_attack = function(self)
 		self.pumpking_timer = (self.pumpking_timer or os.time())
 		if (os.time() - self.pumpking_timer) >3 then
-			set_animation(self, "punch")
+			mobs:set_animation(self, "punch")
 			self.pumpking_timer = os.time()
 			local s = self.object:getpos()
 			local p = self.attack:getpos()


### PR DESCRIPTION
`mobs_redo` has brought the `set_animation` into its namespace

This change fixes NSSM's calls to the global `set_animation` to use `mobs.set_animation` instead.